### PR TITLE
avoid short-circuiting

### DIFF
--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -57,11 +57,30 @@ bool Sensors::init() {
     digitalWrite(reset_pin, 1);
     Wire.begin();
     Wire.setClock(1000); // use slow speed mode
-    return sensor_outside.init() && sensor_inside.init();
+
+    bool all_success = true;
+    if (!sensor_outside.init()){
+        all_success = false;
+        printf("Failed to initialize sensor from outside.\n");
+    }
+    if (!sensor_inside.init()){
+        all_success = false;
+        printf("Failed to initialize sensor from inside.\n");
+    }
+    return all_success;
 }
 
 bool Sensors::update() {
-    return sensor_inside.update() && sensor_outside.update();
+    bool all_success = true;
+    if (!sensor_outside.update()){
+        all_success = false;
+        printf("Failed to update sensor from outside.\n");
+    }
+    if (!sensor_inside.update()){
+        all_success = false;
+        printf("Failed to update sensor from inside.\n");
+    }
+    return all_success;
 }
 
 const Measurements & Sensors::inside() const {


### PR DESCRIPTION
Here's a rephrased version of your message:

When using the `&&` operator, short-circuiting can occur. This means that if one of the sensors cannot be updated, the other sensor will not work either.

There are two ways to solve this issue: 

1. The simple solution is to use an if-else statement.
2. Alternatively, you can use an array which is useful when dealing with multiple sensors. Here's an example in C++:

```
bool all_success = true;
Sensor* sensors[] = {&sensor_inside, &sensor_outside};
for (auto i = 0; i < sizeof(sensors) / sizeof(sensors[0]); ++i) {
    if (!sensors[i]->Init()) {
        all_success = false;
    }
}
return all_success;
``` 

I hope this helps! Let me know if you have any further questions or concerns.